### PR TITLE
Allow microsecond wait times

### DIFF
--- a/src/RetryHandler/Proc.php
+++ b/src/RetryHandler/Proc.php
@@ -37,7 +37,12 @@ class Proc
         $options = array_merge($options, $moreOptions);
 
         $max = isset($options['max']) ? $options['max'] : self::DEFAULT_MAX_RETRY;
-        $wait = isset($options['wait']) ? $options['wait'] : self::DEFAULT_WAIT_TIME;
+        if (isset($options['uwait'])) {
+            $wait = $options['uwait'];
+        } else {
+            $wait = isset($options['wait']) ? $options['wait'] : self::DEFAULT_WAIT_TIME;
+            $wait *= (1000 * 1000);
+        }
         $exception = isset($options['accepted_exception']) ?
             $options['accepted_exception'] :
             self::DEFAULT_ACCEPTED_EXCEPTION;
@@ -56,7 +61,7 @@ class Proc
                 }
             }
             if ($i < $max) {
-                sleep($wait);
+                usleep($wait);
             } else {
                 throw new RetryOverException;
             }

--- a/tests/RetryHandler/ProcTest.php
+++ b/tests/RetryHandler/ProcTest.php
@@ -69,6 +69,19 @@ class ProcTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2 * 2, $end - $begin);
     }
 
+    public function retry_should_wait_specified_milliseconds_before_next_trial()
+    {
+        $proc = new Proc(function() {
+            throw new RuntimeException();
+        });
+        $begin = microtime(true);
+        try {
+            $proc->retry(3, array('uwait' => 100 * 1000));
+        } catch (RetryOverException $e) {}
+        $end = microtime(true);
+        $this->assertEquals(300, round(($end - $begin) * 1000));
+    }
+
     /**
      * @test
      * @expectedException LogicException


### PR DESCRIPTION
Request to allow microsecond wait times, by adding a 'uwait' option, keep functionality the same for 'wait'.  Replaced 'sleep' with 'usleep'.
